### PR TITLE
DatabaseConstants

### DIFF
--- a/EcoMap/src/main/java/com/GREENWORKS/eco/DatabaseConstants.java
+++ b/EcoMap/src/main/java/com/GREENWORKS/eco/DatabaseConstants.java
@@ -1,0 +1,18 @@
+package com.GREENWORKS.eco;
+
+/***
+ * This class is for housing the database constants that we will use during project development. It 
+ * will be necessary for this file to be modified by team members on their remote machines. Constants 
+ * that will probably need to be modified are the USERNAME, PASSWORD, and DATABASE_URL. 
+ * 
+ * DATABASE_URL: MySQL Workbench uses port number 3306 by default. 
+ * USERNAME: Change this to your database username. 
+ * PASSWORD: Change this to your database password.
+ */
+public class DatabaseConstants {
+    private static final String DATABASE_DRIVER = "com.mysql.jdbc.Driver";
+    private static final String DATABASE_URL = "jdbc:mysql://localhost:8889/ecomap"; 
+    private static final String USERNAME = "root";
+    private static final String PASSWORD = "root";
+    private static final String MAX_POOL = "250";
+}


### PR DESCRIPTION
I am moving the database-related constants to their own DatabaseConstants.java file. Intent: Organization. After this pull is merged, I will modify the MySQL MysqlConnect.java to refer to this class for database-related parameters to avoid potential conflicts. 